### PR TITLE
feat: add auth layout

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,24 @@
+'use server'
+import React, { FC, ReactNode } from 'react'
+import { createServerClient } from '@/utils/supabase'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+interface Props {
+  children: ReactNode
+}
+
+const AuthLayout: FC<Props> = async ({ children }) => {
+  const supabase = createServerClient(cookies())
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (user) {
+    redirect('/')
+  }
+
+  return <>{children}</>
+}
+
+export default AuthLayout


### PR DESCRIPTION
### TL;DR

Added an authentication layout that handles the user authentication via supabase, and redirects to the home page if the user is authenticated.

### What changed?

Added a new file `layout.tsx` in the auth directory which implements an authentication layout using Supabase. If an authenticated user is detected, the system automatically redirects to the homepage. The authentication layout is exported as the default export from this module.

### How to test?

To test the implementation, try accessing the application with an authenticated user and an unauthenticated user. The authenticated user should be redirected to the home page while the unauthenticated user should remain on the current page.

### Why make this change?

This change is necessary to ensure that only authenticated users are able to navigate to the other sections of the application. It handles client-side authentication and redirection in a clean and efficient manner, improving the security and the user experience.

---

