### PR TITLE
TIM-105 feat(backend): add newsfeed & connections table

### DIFF
--- a/supabase/migrations/20240508062550_add_newsfeed_table.sql
+++ b/supabase/migrations/20240508062550_add_newsfeed_table.sql
@@ -1,0 +1,20 @@
+create table newsfeed (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade not null,
+  content text not null,
+  created_at timestamp with time zone default now()
+);
+
+alter table newsfeed enable row level security;
+
+create policy "Allow logged-in users to view newsfeed"
+  on newsfeed
+  for select
+  to authenticated
+  using (true);
+
+create policy "Allow logged-in users to insert newsfeed"
+  on newsfeed
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);

--- a/supabase/migrations/20240508083030_add_connections_table.sql
+++ b/supabase/migrations/20240508083030_add_connections_table.sql
@@ -1,0 +1,20 @@
+create table connections (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade not null,
+  connection_user_id uuid references auth.users(id) on delete cascade not null,
+  created_at timestamp with time zone default now()
+);
+
+alter table connections enable row level security;
+
+create policy "Allow logged-in users to view connections"
+  on connections
+  for select
+  to authenticated
+  using (true);
+
+create policy "Allow logged-in users to insert connections"
+  on connections
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
### TL;DR

Added two new tables 'newsfeed' and 'connections' to the database.

### What changed?

The created 'newsfeed' table stores the content posted by users, associated with user id, and time of creation. The 'connections' table keeps track of the established connections between users. User access is controlled through appropriate security policies.

### How to test?

Check if the tables have been created in the database and the security policies are in place. Validate if new entries are being added correctly in the 'newsfeed' and 'connections' tables.

### Why make this change?

These changes were necessary to facilitate the creation of posts by users and track their connections.

---

