### PR TITLE
TIM-109 fix(feed): sort newsfeed by newest first

### DIFF
--- a/src/queries/get-newsfeed.ts
+++ b/src/queries/get-newsfeed.ts
@@ -31,6 +31,7 @@ const getNewsfeed = async (supabase: SupabaseClient) => {
     .from('newsfeed')
     .select('*')
     .in('user_id', connectedUsers)
+    .order('created_at', { ascending: false })
 
   if (error) {
     throw error


### PR DESCRIPTION
### TL;DR

This PR adds an order by clause to the getNewsfeed query to fetch posts in descending order of creation.

### What changed?

The getNewsfeed function was modified to order the newsfeed items by their 'created_at' timestamp in a descending order. This ensures the latest posts are fetched first.

### How to test?

Test by checking if the returned list of posts on the newsfeed are ordered from newest to oldest. 

### Why make this change?

This change was needed to ensure a consistent order of posts shown on the user's newsfeed. With this change, the user will always see the most recent posts at the top of their newsfeed.

---

