### PR TITLE
TIM-150 fix(newsfeed): pfp on posts and publish

### DIFF
--- a/src/components/Post/post-user-profile.tsx
+++ b/src/components/Post/post-user-profile.tsx
@@ -4,11 +4,9 @@ import Avatar, { genConfig } from 'react-nice-avatar'
 import { usePostContext } from '@/components/Post/Post'
 import { format } from 'date-fns'
 
-const email = 'email@gmail.com'
-
 const PostUserProfile = () => {
   const { post } = usePostContext()
-  const config = genConfig(email)
+  const config = genConfig(post.user_id)
 
   return (
     <div className={'flex flex-row gap-2.5 px-4 pt-4'}>

--- a/src/components/Publish/publish-input.tsx
+++ b/src/components/Publish/publish-input.tsx
@@ -1,13 +1,14 @@
-import React, { FC } from 'react'
-import { Textarea } from '@/components/ui/textarea'
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { useFormContext } from 'react-hook-form'
 import {
   FormControl,
   FormField,
   FormItem,
   FormMessage,
 } from '@/components/ui/form'
+import { Textarea } from '@/components/ui/textarea'
+import { useUser } from '@/providers/UserProvider'
+import { FC } from 'react'
+import { useFormContext } from 'react-hook-form'
+import Avatar, { genConfig } from 'react-nice-avatar'
 
 interface Props {
   setIsOpen: (_isOpen: boolean) => void
@@ -16,13 +17,12 @@ interface Props {
 
 const PublishInput: FC<Props> = ({ setIsOpen, isPending }) => {
   const { control } = useFormContext()
+  const user = useUser()
+  const config = genConfig(user?.user_id ?? '')
 
   return (
     <div className={'flex flex-row gap-5 px-4 pb-10'}>
-      <Avatar>
-        <AvatarImage src={'https://picsum.photos/200/300'} />
-        <AvatarFallback>JD</AvatarFallback>
-      </Avatar>
+      <Avatar {...config} className="h-10 w-10 shrink-0 rounded-full" />
       <FormField
         control={control}
         name={'content'}


### PR DESCRIPTION
### TL;DR

This Pull Request updates the Avatar generation method and integrates user context in the Post and Publish components.

### What changed?

- In the Post component, the Avatar generation is now based on the user_id of the post, instead of using a hard-coded email.

- In the Publish component, the Avatar is generated based on the user_id provided by the UserProvider context, instead of using a static image and fallback. Also, user object is now captured directly from UserProvider context.

### How to test?

- Navigate to the pages with Post and Publish components to see if Avatars are generated correctly with the new method.

- Test with accounts with different user_ids and observe if Avatars are changing according to the User context.

### Why make this change?

This change improves the customization capabilities of the Avatar feature by making it context-aware. The Avatars now represent a specific user, enhancing the user experience and making posts more personalized.

---

