### PR TITLE
TIM-151 fix(search): pfp on search results

### DIFF
--- a/src/components/search/search-result.tsx
+++ b/src/components/search/search-result.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const SearchResult: FC<Props> = ({ profile }) => {
-  const config = genConfig(profile.email || 'email')
+  const config = genConfig(profile.user_id || '')
   const { toast } = useToast()
   const queryClient = useQueryClient()
 


### PR DESCRIPTION
### TL;DR

This PR updates the `genConfig` call in `search-result.tsx` to use `profile.user_id` instead of `profile.email`.

### What changed?

In the `search-result.tsx` file, the `genConfig` function now uses `profile.user_id` instead of `profile.email`.

### How to test?

To test, use the search functionality and observe the results, the user_id should now be used for generating config.

### Why make this change?

The motivation behind this change is to replace the use of potentially sensitive information (email) with a less sensitive one (user_id) and to unify the usage of identifiers in the codebase.

---

