### PR TITLE
TIM-155 feat(newsfeed): add function to fetch newsfeed-likes

### DIFF
--- a/src/app/(home)/(feed)/format-likers.ts
+++ b/src/app/(home)/(feed)/format-likers.ts
@@ -1,0 +1,39 @@
+import { Tables } from '@/types/database.types'
+
+type Liker = Tables<'newsfeed_likes'> & {
+  user_profiles: {
+    first_name: string
+    user_id: string
+    email: string
+  }
+}
+
+const formatLikers = (likers: Liker[]): string => {
+  if (likers.length === 0) {
+    return ''
+  }
+
+  const names = likers.map(
+    (liker) => liker.user_profiles?.first_name || 'Unknown',
+  )
+
+  if (names.length === 1) {
+    return names[0]
+  }
+
+  return names.slice(0, 2).join(', ')
+}
+
+const countLikers = (likers: Liker[]): number => {
+  const likerCount = likers.length
+  if (likerCount > 2) {
+    return likerCount - 2
+  } else {
+    return 0
+  }
+}
+const getLikerUserIds = (likers: Liker[]): string[] => {
+  return likers.slice(0, 3).map((l) => l.user_profiles.user_id)
+}
+
+export { formatLikers, countLikers, getLikerUserIds }

--- a/src/queries/get-newsfeed_likes.ts
+++ b/src/queries/get-newsfeed_likes.ts
@@ -1,0 +1,43 @@
+import { createBrowserClient } from '@/utils/supabase'
+
+const getNewsfeedLikes = async (newsfeed_id: string) => {
+  const supabase = createBrowserClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from('newsfeed_likes')
+    .select('*, user_profiles(first_name, user_id, email)')
+    .eq('newsfeed_id', newsfeed_id)
+
+  if (error) {
+    console.log(error.message)
+    return []
+  }
+
+  const formattedLikes = data.map((like) => {
+    if (like.user_id === user.id) {
+      return {
+        ...like,
+        user_profiles: { ...like.user_profiles, first_name: 'You' },
+      }
+    }
+    return like
+  })
+
+  formattedLikes.sort((a, b) => {
+    if (a.user_id === user.id) return -1
+    if (b.user_id === user.id) return 1
+    return 0
+  })
+
+  return formattedLikes
+}
+
+export default getNewsfeedLikes


### PR DESCRIPTION
### TL;DR

This PR introduces new utility functions for formatting and counting the likers of a post, as well as fetching the likers from the newsfeed.

### What changed?

Two new files have been added: `format-likers.ts` in the home/feed directory which includes functions for formatting liker data, and `get-newsfeed_likes.ts` in the queries directory for fetching likes associated with a newsfeed post. Added functionality to handle 'unknown' liker, list two likers by first name, and count extra likers if there are more than two.

### How to test?

Test these by checking the formatted data for likers on the newsfeed likes, check the responses from the `getNewsfeedLikes` query.

### Why make this change?

This change provides necessary functionalities for a robust and dynamic display of 'likes' on a post in the newsfeed

---

